### PR TITLE
refactor: change all deps to forks for hu55a1n1 decaf377 support

### DIFF
--- a/zk/arkworks/gramine/Cargo.toml
+++ b/zk/arkworks/gramine/Cargo.toml
@@ -19,22 +19,22 @@ ark-relations                    = { version = "0.4.0", default-features = false
 ark-snark                        = { version = "0.4.0", default-features = false }
 base64                           = { version = "0.21.7", default-features = false }
 blake2b_simd                     = { version = "1.0.2", default-features = false }
-decaf377                         = { version = "0.10.1" }
-decaf377-fmd                     = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.9" }
-decaf377-ka                      = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.9" }
-decaf377-rdsa                    = { version = "0.11.0" }
+decaf377                         = { git = "https://github.com/hu55a1n1/decaf377.git" }
+decaf377-ka                      = { git = "https://github.com/dangush/penumbra.git", branch = "v0.80.9-fork" }
+decaf377-fmd                     = { git = "https://github.com/dangush/penumbra.git", branch = "v0.80.9-fork" }
+decaf377-rdsa                    = { git = "https://github.com/dangush/decaf377-rdsa.git" }
 hex                              = { version = "0.4.3", default-features = false }
 once_cell                        = { version = "1.20.2", default-features = false }
-penumbra-asset                   = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.9" }
-penumbra-keys                    = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.9" }
-penumbra-num                     = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.9" }
-penumbra-proof-params            = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.9" }
-penumbra-proof-setup            = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.9" }
-penumbra-proto                   = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.9" }
-penumbra-shielded-pool           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.9" }
-penumbra-tct                     = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.9" }
-poseidon377                      = { version = "1.2.0", default-features = false }
-poseidon-parameters              = { version = "1.1.0" }
+penumbra-asset                   = { git = "https://github.com/dangush/penumbra.git", branch = "v0.80.9-fork" }
+penumbra-keys                    = { git = "https://github.com/dangush/penumbra.git", branch = "v0.80.9-fork" }
+penumbra-num                     = { git = "https://github.com/dangush/penumbra.git", branch = "v0.80.9-fork" }
+penumbra-proof-params            = { git = "https://github.com/dangush/penumbra.git", branch = "v0.80.9-fork" }
+penumbra-proof-setup             = { git = "https://github.com/dangush/penumbra.git", branch = "v0.80.9-fork" }
+penumbra-proto                   = { git = "https://github.com/dangush/penumbra.git", branch = "v0.80.9-fork" }
+penumbra-shielded-pool           = { git = "https://github.com/dangush/penumbra.git", branch = "v0.80.9-fork" }
+penumbra-tct                     = { git = "https://github.com/dangush/penumbra.git", branch = "v0.80.9-fork" }
+poseidon377                      = { git = "https://github.com/dangush/poseidon377.git", default-features = false}
+poseidon-parameters              = { git = "https://github.com/dangush/poseidon377.git" }
 rand_core                        = { version = "0.6.4", default-features = false }
 serde                            = { version = "1.0.216", features = ["derive"], default-features = false }
 tracing                          = { version = "0.1.41", default-features = false }
@@ -46,3 +46,5 @@ serde_json                       = { version = "1.0.135" }
 
 [patch.crates-io]
 decaf377                         = { git = "https://github.com/hu55a1n1/decaf377.git" }
+poseidon377                      = { git = "https://github.com/dangush/poseidon377.git" }
+poseidon-parameters              = { git = "https://github.com/dangush/poseidon377.git" }

--- a/zk/arkworks/gramine/src/main.rs
+++ b/zk/arkworks/gramine/src/main.rs
@@ -5,8 +5,6 @@ use std::path::{Path, PathBuf};
 use anyhow::Error;
 use ark_groth16::{ProvingKey, VerifyingKey};
 use ark_serialize::CanonicalSerialize;
-use arkworks_gramine::output::OutputCircuit;
-use arkworks_gramine::settlement::SettlementCircuit;
 use decaf377::Bls12_377;
 use penumbra_proof_params::{
     generate_constraint_matrices, DummyWitness, ProvingKeyExt, VerifyingKeyExt,
@@ -17,11 +15,9 @@ use penumbra_proof_setup::single::{
 };
 use rand_core::OsRng;
 
-pub mod note;
-pub mod nullifier;
-pub mod output;
-pub mod proof_bundle;
-pub mod settlement;
+use arkworks_gramine::{
+    output::OutputCircuit, settlement::SettlementCircuit
+};
 
 fn generate_parameters<D: DummyWitness>() -> (ProvingKey<Bls12_377>, VerifyingKey<Bls12_377>) {
     let matrices = generate_constraint_matrices::<D>();


### PR DESCRIPTION
## Summary

Switches all penumbra dependencies (from penumbra repo as well as decaf377-rdsa, poseidon) to forks which import our fork of decaf377.

