### PR TITLE
feat: trait for bijective encoding of notes to field elements

### DIFF
--- a/zk/arkworks/gramine/src/canonical.rs
+++ b/zk/arkworks/gramine/src/canonical.rs
@@ -1,0 +1,204 @@
+use ark_ff::ToConstraintField;
+use decaf377::Fq;
+use decaf377_ka as ka;
+use penumbra_asset::Value;
+use penumbra_keys::keys::{Diversifier, DIVERSIFIER_LEN_BYTES};
+use penumbra_keys::Address;
+use penumbra_num::Amount;
+use penumbra_shielded_pool::Rseed;
+
+use crate::note::Note;
+
+pub trait CanonicalFqEncoding {
+    fn canonical_encoding(&self) -> Vec<Fq>;
+}
+
+pub trait CanonicalFqDecoding {
+    fn canonical_decoding(fqs: &[Fq]) -> anyhow::Result<Self> where Self: Sized;
+}
+
+impl CanonicalFqEncoding for Note {
+    fn canonical_encoding(&self) -> Vec<Fq> {
+        let mut value_encoded = self.value().to_field_elements().unwrap();
+        let mut rseed_encoded = self.rseed().0.canonical_encoding(); // [u8; 32] -> [Fq; 2] conversion
+        let mut debtor_encoded = self.debtor().canonical_encoding();
+        let mut creditor_encoded = self.creditor().canonical_encoding();
+        
+        let mut res = Vec::new();
+        res.append(&mut value_encoded);
+        res.append(&mut rseed_encoded);
+        res.append(&mut debtor_encoded);
+        res.append(&mut creditor_encoded);
+
+        res
+    }
+}
+
+/// Implements the canonical decoding of a `Note` from a slice of field elements.
+/// 
+/// The slice must contain exactly **12** `Fq` elements:
+/// - `fqs[0..2]` for [`Value`]
+/// - `fqs[2..4]` for [`Rseed`]
+/// - `fqs[4..8]` for the debtor [`Address`]
+/// - `fqs[8..12]` for the creditor [`Address`]
+impl CanonicalFqDecoding for Note {
+    fn canonical_decoding(fqs: &[Fq]) -> anyhow::Result<Note> {
+        if fqs.len() != 12 {
+            return Err(anyhow::anyhow!("Expected 12 Fq elements for Note, got {}", fqs.len()));
+        }
+    
+        let value_encoded = &fqs[0..2];
+        let rseed_encoded = &fqs[2..4];
+        let debtor_encoded = &fqs[4..8];
+        let creditor_encoded = &fqs[8..12];
+    
+        let value = Value::canonical_decoding(value_encoded)?;
+    
+        // For Rseed, we use our bijective mapping from 32-byte encoding into 2 × Fq.
+        let rseed = Rseed(<[u8; 32]>::canonical_decoding(&rseed_encoded)?);
+    
+        let debtor = Address::canonical_decoding(debtor_encoded)?;
+        let creditor = Address::canonical_decoding(creditor_encoded)?;
+    
+        Note::from_parts(debtor, creditor, value, rseed).map_err(Into::into)
+    }
+}
+
+impl CanonicalFqEncoding for Address {
+    fn canonical_encoding(&self) -> Vec<Fq> {
+        // Store the [u8; 16] diversifier bytes as an Fq
+        let diversifier = Fq::from_le_bytes_mod_order(&self.diversifier().0);
+        let pkd = self.transmission_key_s().clone();
+        let cluekey = self.clue_key().0.canonical_encoding(); // [u8; 32] -> [Fq; 2] conversion
+        
+        vec![diversifier, pkd, cluekey[0], cluekey[1]]
+    }
+}
+
+/// Implements the canonical decoding of an [`Address`] from a slice of [`Fq`] elements.
+///
+/// The slice must contain exactly **4** `Fq` elements:
+/// - `fqs[0]`: Encodes the diversifier. Only the first `DIVERSIFIER_LEN_BYTES` of its canonical bytes
+///   are used to form a [`Diversifier`].
+/// - `fqs[1]`: Encodes the transmission key, whose canonical bytes are used as the public key component.
+/// - `fqs[2]` and `fqs[3]`: Together, these two elements encode the clue key via our bijective mapping.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The slice length is not exactly 4.
+/// - Converting the diversifier field into the required fixed-size array fails.
+/// - Constructing an [`Address`] from its components fails.
+impl CanonicalFqDecoding for Address {
+    fn canonical_decoding(fqs: &[Fq]) -> anyhow::Result<Address> {
+        if fqs.len() != 4 {
+            return Err(anyhow::anyhow!(
+                "Expected 4 Fq elements for Address, got {}",
+                fqs.len()
+            ));
+        }
+        let diversifier_fq = fqs[0];
+        let transmission_fq = fqs[1];
+        let clue_key_fqs = &fqs[2..4];
+        
+        let diversifier_bytes: [u8; DIVERSIFIER_LEN_BYTES] = diversifier_fq
+            .to_bytes()[..DIVERSIFIER_LEN_BYTES]
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("slice length must be DIVERSIFIER_LEN_BYTES for diversifier"))?;
+
+        let d = Diversifier(diversifier_bytes);
+        let pk_d = ka::Public(transmission_fq.to_bytes());
+        let ck_d = decaf377_fmd::ClueKey(<[u8; 32]>::canonical_decoding(&clue_key_fqs)?);
+        
+        Address::from_components(d, pk_d, ck_d)
+            .ok_or_else(|| anyhow::anyhow!("couldn't build Address from components"))
+    }
+}
+
+
+impl CanonicalFqEncoding for Value {
+    fn canonical_encoding(&self) -> Vec<Fq> {
+        let amount = self.amount.to_field_elements().expect("expect amount encoding");
+        assert_eq!(amount.len(), 1);
+        let id = self.asset_id.0;
+
+        vec![amount[0], id]
+    }
+}
+
+/// Implements the canonical decoding of a [`Value`] from a slice of [`Fq`] elements.
+///
+/// The slice must contain exactly **2** `Fq` elements:
+/// - `fqs[0]`: Encodes the `Amount`, where the first 16 bytes (in little-endian order) represent a `u128`.
+/// - `fqs[1]`: Encodes the asset identifier, wrapped in the [`Id`] type.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The slice length is not exactly 2.
+/// - Converting the first element into a 16-byte slice fails.
+impl CanonicalFqDecoding for Value {
+    fn canonical_decoding(fqs: &[Fq]) -> anyhow::Result<Value> {
+        use penumbra_asset::asset::Id;
+
+        // Expecting two Fq elements:
+        // - the first encodes the first 16 bytes of the u128 (little endian)
+        // - the second encodes the asset id.
+        if fqs.len() != 2 {
+            return Err(anyhow::anyhow!(
+                "Expected 2 Fq elements for Value, got {}",
+                fqs.len()
+            ));
+        }
+
+        let amount_bytes: [u8; 16] = fqs[0]
+            .to_bytes()[..16]
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("slice length must be 16 for Amount"))?;
+        let amount = Amount::from_le_bytes(amount_bytes);
+        let asset_id = Id(fqs[1]);
+        
+        Ok(Value { amount, asset_id })
+    }
+}
+
+/// Implements a bijective canonical encoding for a 32-byte array into two [`Fq`] elements.
+///
+/// Because [`Fq::from_le_bytes_mod_order`] reduces modulo the field modulus (which is 2^253),
+/// using it directly on 32 bytes is lossy. We split the array into:
+///
+/// - The first 31 bytes (with the 32nd byte zeroed), and
+/// - The original 32nd byte (stored as the LSB in a separate 32-byte array).
+///
+/// This mapping is reversible via [`CanonicalFqDecoding`]
+impl CanonicalFqEncoding for [u8; 32] {
+    fn canonical_encoding(&self) -> Vec<Fq> {
+        let mut bottom_bytes = self.clone();
+        bottom_bytes[31] = 0u8;
+        let mut top_bytes = [0u8; 32];
+        top_bytes[0] = self[31];
+    
+        vec![
+            Fq::from_le_bytes_mod_order(&bottom_bytes),
+            Fq::from_le_bytes_mod_order(&top_bytes)
+        ]
+    }
+}
+
+/// Reconstructs a `[u8; 32]` from two [`Fq`] elements produced by [`CanonicalFqEncoding`].
+///
+/// The first Fq recovers the lower 31 bytes and the second Fq recovers the original 32nd byte.
+impl CanonicalFqDecoding for [u8; 32] {
+    fn canonical_decoding(fqs: &[Fq]) -> anyhow::Result<[u8; 32]> {
+        let bottom_bytes = fqs[0].to_bytes();
+        let top_bytes = fqs[1].to_bytes();
+    
+        let mut bytes = [0u8; 32];
+        // The original lower 31 bytes will be the lower 31 bytes of bottom_bytes.
+        bytes[..31].copy_from_slice(&bottom_bytes[..31]);
+        // The original 32nd byte is stored in the least-significant position of top_bytes
+        bytes[31] = top_bytes[0];
+    
+        Ok(bytes)
+    }
+}

--- a/zk/arkworks/gramine/src/encryption.rs
+++ b/zk/arkworks/gramine/src/encryption.rs
@@ -46,9 +46,11 @@ pub fn ecies_decrypt(s: SharedSecret, c2: Ciphertext) -> Result<Plaintext, Error
 mod tests {
     use decaf377::{Element, Encoding, Fq};
     use decaf377_ka::{Secret, SharedSecret};
+    use penumbra_asset::{asset::Id, Value};
+    use penumbra_shielded_pool::Rseed;
     use rand_core::OsRng;
 
-    use crate::encryption::{ecies_decrypt, ecies_encrypt};
+    use crate::{canonical::{CanonicalFqDecoding, CanonicalFqEncoding}, encryption::{ecies_decrypt, ecies_encrypt}, note::Note};
 
     fn ss_as_element(ss: SharedSecret) -> Element {
         Encoding(ss.0).vartime_decompress().unwrap()
@@ -65,5 +67,36 @@ mod tests {
         let ciphertext = ecies_encrypt(ss_as_element(s.clone()), msg.clone()).unwrap();
         let msg_dec = ecies_decrypt(ss_as_element(s), ciphertext).unwrap();
         assert_eq!(msg, msg_dec);
+    }
+
+    #[test]
+    fn test_note_encryption_roundtrip() {
+        let mut rng = OsRng;
+
+        let original = Note::from_parts(
+            penumbra_keys::test_keys::ADDRESS_1.clone(),
+            penumbra_keys::test_keys::ADDRESS_0.clone(),
+            Value {
+                amount: 10u64.into(),
+                asset_id: Id(Fq::from(1u64)),
+            },
+            Rseed::generate(&mut rng),
+        )
+        .expect("hardcoded note");
+
+
+        let r = Secret::new(&mut rng);
+        let receiver_sk = Secret::new(&mut rng);
+        let receiver_pk = receiver_sk.public();
+        let s = r.key_agreement_with(&receiver_pk).unwrap();
+
+        let msg: Vec<Fq> = original.canonical_encoding();
+
+        let ciphertext = ecies_encrypt(ss_as_element(s.clone()), msg.clone()).unwrap();
+        let msg_dec = ecies_decrypt(ss_as_element(s), ciphertext).unwrap();
+
+        let note = Note::canonical_decoding(&msg_dec).unwrap();
+
+        assert_eq!(note, original);
     }
 }

--- a/zk/arkworks/gramine/src/encryption.rs
+++ b/zk/arkworks/gramine/src/encryption.rs
@@ -47,6 +47,7 @@ mod tests {
     use decaf377::{Element, Encoding, Fq};
     use decaf377_ka::{Secret, SharedSecret};
     use penumbra_asset::{asset::Id, Value};
+    use penumbra_keys::Address;
     use penumbra_shielded_pool::Rseed;
     use rand_core::OsRng;
 
@@ -73,30 +74,33 @@ mod tests {
     fn test_note_encryption_roundtrip() {
         let mut rng = OsRng;
 
-        let original = Note::from_parts(
-            penumbra_keys::test_keys::ADDRESS_1.clone(),
-            penumbra_keys::test_keys::ADDRESS_0.clone(),
-            Value {
-                amount: 10u64.into(),
-                asset_id: Id(Fq::from(1u64)),
-            },
-            Rseed::generate(&mut rng),
-        )
-        .expect("hardcoded note");
-
-
-        let r = Secret::new(&mut rng);
-        let receiver_sk = Secret::new(&mut rng);
-        let receiver_pk = receiver_sk.public();
-        let s = r.key_agreement_with(&receiver_pk).unwrap();
-
-        let msg: Vec<Fq> = original.canonical_encoding();
-
-        let ciphertext = ecies_encrypt(ss_as_element(s.clone()), msg.clone()).unwrap();
-        let msg_dec = ecies_decrypt(ss_as_element(s), ciphertext).unwrap();
-
-        let note = Note::canonical_decoding(&msg_dec).unwrap();
-
-        assert_eq!(note, original);
+        for _ in 0..100 {
+            let original = Note::from_parts(
+                Address::dummy(&mut rng),
+                Address::dummy(&mut rng),
+                Value {
+                    amount: 10u64.into(),
+                    asset_id: Id(Fq::from(1u64)),
+                },
+                Rseed::generate(&mut rng),
+            )
+            .expect("hardcoded note");
+    
+    
+            let r = Secret::new(&mut rng);
+            let receiver_sk = Secret::new(&mut rng);
+            let receiver_pk = receiver_sk.public();
+            let s = r.key_agreement_with(&receiver_pk).unwrap();
+    
+            let msg: Vec<Fq> = original.canonical_encoding();
+    
+            let ciphertext = ecies_encrypt(ss_as_element(s.clone()), msg.clone()).unwrap();
+            let msg_dec = ecies_decrypt(ss_as_element(s), ciphertext).unwrap();
+    
+            let note = Note::canonical_decoding(&msg_dec).unwrap();
+    
+            assert_eq!(note, original);
+    
+        }
     }
 }

--- a/zk/arkworks/gramine/src/lib.rs
+++ b/zk/arkworks/gramine/src/lib.rs
@@ -4,3 +4,4 @@ pub mod nullifier;
 pub mod output;
 pub mod proof_bundle;
 pub mod settlement;
+pub mod canonical;

--- a/zk/arkworks/gramine/src/note/mod.rs
+++ b/zk/arkworks/gramine/src/note/mod.rs
@@ -260,16 +260,7 @@ impl ToCanonicalEncoding for Note {
         let rseed_encoded: Vec<Fq> = fq_from_bytes_bijective(self.rseed.0).into_iter().collect();
         let debtor_encoded = self.debtor.canonical_encoding();
         let creditor_encoded = self.creditor.canonical_encoding();
-
-        // value: Value,
-        // /// A uniformly random 32-byte sequence used to derive an ephemeral secret key
-        // /// and note blinding factor.
-        // rseed: Rseed,
-        // /// The address controlling this note.
-        // debtor: Address,
-        // /// The credit of this note.
-        // creditor: Address,
-
+        
         vec![
             value_encoded,
             rseed_encoded,


### PR DESCRIPTION
## Summary

This PR fixes the issue of not having a bijective mapping between the Note type and field elements such that you can do a round trip conversion. This is necessary for deserializing Notes from decrypted note ciphertexts. 

The original approach was a naive one of serializing a note into bytes, then converting each byte into a Fq as to ensure a bijective mapping. 

This approach uses the Note's underlying types to maximally efficiently encode the note, utilizing Field element types directly wherever possible. 

## TODO
- [x] Settle on the right term for this - canonical or bijective or something and fix trait name
- [x] Implement a decoder trait for all the types and call them in a nested fashion rather than implementing it all only for Notes
- [x] test with encryption just for sanity